### PR TITLE
Add apel-pkg.el (used by MELPA).

### DIFF
--- a/apel-pkg.el
+++ b/apel-pkg.el
@@ -1,0 +1,2 @@
+(define-package "apel" "10.8"
+  "APEL (A Portable Emacs Library) provides support for portable Emacs Lisp programs")


### PR DESCRIPTION
This required to get apel into the MELPA package archive.
