### PR TITLE
Feature/melpa

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2014-10-11  Erik Hetzner <egh@e6h.org>
+
+	* pces-20.el: Only check for broken insert-file-contents-literally
+	on emacs older than 23, to prevent error in byte-compilation via
+	package installation.
+
 2014-06-05  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* mcs-20.el (detect-mime-charset-from-coding-system): (Emacs23 and

--- a/apel-pkg.el
+++ b/apel-pkg.el
@@ -1,0 +1,2 @@
+(define-package "apel" "10.9"
+  "APEL (A Portable Emacs Library) provides support for portable Emacs Lisp programs")

--- a/pces-20.el
+++ b/pces-20.el
@@ -60,73 +60,78 @@
 	jka-compr-compression-info-list jam-zcat-filename-list)
     (write-region start end filename append visit lockname)))
 
-(require 'broken)
+(eval-when-compile (require 'broken))
+(static-when (>= emacs-major-version 23)
+  (defalias 'insert-file-contents-as-binary 'insert-file-contents-literally))
 
-(broken-facility insert-file-contents-literally-treats-binary
-  "Function `insert-file-contents-literally' decodes text."
-  (let* ((str "\r\n")
-	 (coding-system-for-write 'binary)
-	 (coding-system-for-read 'raw-text-dos)
-         ;; (default-enable-multibyte-characters (multibyte-string-p str))
-	 )
-    (with-temp-buffer
-      (insert str)
-      (write-region (point-min)(point-max) "literal-test-file")
-      )
-    (string=
-     (with-temp-buffer
-       (let (file-name-handler-alist)
-	 (insert-file-contents-literally "literal-test-file")
-	 )
-       (buffer-string)
-       )
-     str)))
+(static-when (< emacs-major-version 23)
 
-(broken-facility insert-file-contents-literally-treats-file-name-handler
-  "Function `insert-file-contents' doesn't call file-name-handler."
-  (let (called)
-    (with-temp-buffer
-      (let ((file-name-handler-alist
-	     '(("literal-test-file" . (lambda (operation &rest args)
-					(setq called t)
-					(let (file-name-handler-alist)
-					  (apply operation args)
-					  ))))))
-	(insert-file-contents-literally "literal-test-file")
-	)
-      (delete-file "literal-test-file")
-      )
-    called))
+  (broken-facility insert-file-contents-literally-treats-binary
+    "Function `insert-file-contents-literally' decodes text."
+    (let* ((str "\r\n")
+  	 (coding-system-for-write 'binary)
+  	 (coding-system-for-read 'raw-text-dos)
+           ;; (default-enable-multibyte-characters (multibyte-string-p str))
+  	 )
+      (with-temp-buffer
+        (insert str)
+        (write-region (point-min)(point-max) "literal-test-file")
+        )
+      (string=
+       (with-temp-buffer
+         (let (file-name-handler-alist)
+  	 (insert-file-contents-literally "literal-test-file")
+  	 )
+         (buffer-string)
+         )
+       str)))
 
-(static-if
-    (or (broken-p 'insert-file-contents-literally-treats-binary)
-	(broken-p 'insert-file-contents-literally-treats-file-name-handler))
-    (defun insert-file-contents-as-binary (filename
-					   &optional visit beg end replace)
-      "Like `insert-file-contents', but only reads in the file literally.
+  (broken-facility insert-file-contents-literally-treats-file-name-handler
+    "Function `insert-file-contents' doesn't call file-name-handler."
+    (let (called)
+      (with-temp-buffer
+        (let ((file-name-handler-alist
+  	     '(("literal-test-file" . (lambda (operation &rest args)
+  					(setq called t)
+  					(let (file-name-handler-alist)
+  					  (apply operation args)
+  					  ))))))
+  	(insert-file-contents-literally "literal-test-file")
+  	)
+        (delete-file "literal-test-file")
+        )
+      called))
+
+  (static-if
+      (or (broken-p 'insert-file-contents-literally-treats-binary)
+  	(broken-p 'insert-file-contents-literally-treats-file-name-handler))
+      (defun insert-file-contents-as-binary (filename
+  					   &optional visit beg end replace)
+        "Like `insert-file-contents', but only reads in the file literally.
 A buffer may be modified in several ways after reading into the buffer,
 to Emacs features such as format decoding, character code
 conversion, find-file-hooks, automatic uncompression, etc.
 
 This function ensures that none of these modifications will take place."
-      (let ((format-alist nil)
-	    (after-insert-file-functions nil)
-	    (coding-system-for-read 'binary)
-	    (coding-system-for-write 'binary)
-	    (jka-compr-compression-info-list nil)
-	    (jam-zcat-filename-list nil)
-	    (find-buffer-file-type-function
-	     (if (fboundp 'find-buffer-file-type)
-		 (symbol-function 'find-buffer-file-type)
-	       nil)))
-	(unwind-protect
-	    (progn
-	      (fset 'find-buffer-file-type (lambda (filename) t))
-	      (insert-file-contents filename visit beg end replace))
-	  (if find-buffer-file-type-function
-	      (fset 'find-buffer-file-type find-buffer-file-type-function)
-	    (fmakunbound 'find-buffer-file-type)))))
-  (defalias 'insert-file-contents-as-binary 'insert-file-contents-literally)
+        (let ((format-alist nil)
+  	    (after-insert-file-functions nil)
+  	    (coding-system-for-read 'binary)
+  	    (coding-system-for-write 'binary)
+  	    (jka-compr-compression-info-list nil)
+  	    (jam-zcat-filename-list nil)
+  	    (find-buffer-file-type-function
+  	     (if (fboundp 'find-buffer-file-type)
+  		 (symbol-function 'find-buffer-file-type)
+  	       nil)))
+  	(unwind-protect
+  	    (progn
+  	      (fset 'find-buffer-file-type (lambda (filename) t))
+  	      (insert-file-contents filename visit beg end replace))
+  	  (if find-buffer-file-type-function
+  	      (fset 'find-buffer-file-type find-buffer-file-type-function)
+  	    (fmakunbound 'find-buffer-file-type)))))
+    (defalias 'insert-file-contents-as-binary 'insert-file-contents-literally)
+    )
   )
 
 (defun insert-file-contents-as-raw-text (filename


### PR DESCRIPTION
Hi,

I would like to merge these two changes into APEL. The first is a package description, to be used when building a package (via MELPA). The second is a fix for the issue described here:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=166226

which occurs when byte-compiling `pces-20.el` when the current directory is read-only.

I tested the function `insert-file-contents-literally` on emacs >= 23 and it works fine, so I don't think we need this check on modern emacs.
