### PR TITLE
Add library apel.el whose name matches that of the package apel

### DIFF
--- a/apel.el
+++ b/apel.el
@@ -1,0 +1,31 @@
+;;; apel.el --- support for portable Emacs Lisp programs
+
+;; Copyright (C) 1996-2017  Free Software Foundation, Inc.
+
+;; This file is part of APEL (A Portable Emacs Library).
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;; APEL (A Portable Emacs Library) provides support for portable Emacs
+;; Lisp programs.
+
+;;; Code:
+
+(provide 'apel)
+
+;;; apel.el ends here


### PR DESCRIPTION
A package should always contain a library with the same name.
One benefit of that is that Melpa can then extract the package
description from the library commentary.