### PR TITLE
Fix compile error of pccl-20.el with Emacs 28

### DIFF
--- a/pccl-20.el
+++ b/pccl-20.el
@@ -88,8 +88,9 @@ CODING-SYSTEM, DECODER and ENCODER must be symbol."
       (when-broken ccl-accept-symbol-as-program
 	(setq decoder (symbol-value decoder))
 	(setq encoder (symbol-value encoder)))
-      (make-coding-system coding-system 4 mnemonic docstring
-			  (cons decoder encoder)))
+    (if (fboundp 'make-coding-system)
+      (make-coding-system coding-system 4 mnemonic docstring (cons decoder encoder))
+      (define-coding-system coding-system docstring :mnemonic mnemonic :coding-type 'ccl :ccl-decoder decoder :ccl-encoder encoder)))
     )
 
   (when-broken ccl-accept-symbol-as-program


### PR DESCRIPTION
Hello, I am the FreeBSD port maintainer of APEL.
Recently make-coding-system function was removed from Emacs (commit log: https://github.com/emacs-mirror/emacs/commit/874ba85363e90a54f976af542e9b3f4c662e317e) and this removal causes compile error of pccl-20.el with Emacs 28.
I fixed the error by using define-coding-system instead of make-coding-system if make-coding-system is missing.

Excerpt of error log:
```
=======================<phase: build          >============================
===>  Building for apel-emacs28-10.8.20190407_3
/usr/local/bin/emacs-28.0.50 -batch -q -no-site-file -l APEL-MK -f compile-apel  /wrkdirs/usr/ports/editors/apel/work-devel_full/stage/usr/local /wrkdirs/usr/ports/editors/apel/work-devel_full/stage/usr/local/share/emacs/28.0.50/site-lisp /wrkdirs/usr/ports/editors/apel/work-devel_full/stage/usr/local/share/emacs/28.0.50/site-lisp
Loading /wrkdirs/usr/ports/editors/apel/work-devel_full/apel-d146ddb/APEL-CFG...
Loading /wrkdirs/usr/ports/editors/apel/work-devel_full/apel-d146ddb/APEL-ELS...
Loading /wrkdirs/usr/ports/editors/apel/work-devel_full/apel-d146ddb/EMU-ELS...


In apel-version:
apel-ver.el:55:10: Warning: `interactive-p' is an obsolete function (as of
    23.2); use `called-interactively-p' instead.

In toplevel form:
pccl-20.el:131:25: Error: Symbol's function definition is void: make-coding-system
byte-compile-dynamic is obsolete (since 27.1); not worthwhile any more.
byte-compile-dynamic is obsolete (since 27.1); not worthwhile any more.
byte-compile-dynamic is obsolete (since 27.1); not worthwhile any more.
byte-compile-dynamic is obsolete (since 27.1); not worthwhile any more.
```

Full error log: http://beefy6.nyi.freebsd.org/data/121amd64-default/545479/logs/apel-emacs28-10.8.20190407_3.log