### PR TITLE
Don't use defun-maybe for mime-charset-list

### DIFF
--- a/mcs-e20.el
+++ b/mcs-e20.el
@@ -129,7 +129,7 @@ Return nil if corresponding MIME-charset is not found."
 				   (symbol-name result)))
 	  result))))
 
-(defun-maybe mime-charset-list ()
+(defun mime-charset-list ()
   "Return a list of all existing MIME-charset."
   (let ((dest (mapcar (function car) mime-charset-coding-system-alist))
 	(rest coding-system-list)


### PR DESCRIPTION
```
* mcs-e20.el (mime-charset-list): Use `defun' instead of
`defun-maybe'.
```

I've noticed that loading mcharset.el fails because of void-function
defun-maybe in mcs-e20.el.

```
$ LC_ALL=C emacs -Q -batch -eval "(add-to-list 'load-path \".\")" -l mcharset.el
Symbol's function definition is void: defun-maybe
```

This pach replaces `defun-maybe` with `defun` to fix this issue.

If this `defun-maybe` is really needed, use `(require 'pym)`
instead of this patch.
