### PR TITLE
Revive dependency to compatible with APEL

### DIFF
--- a/pces.el
+++ b/pces.el
@@ -24,6 +24,7 @@
 
 ;;; Code:
 
+(require 'poe)
 (require 'pces-e20)
 
 	 

--- a/poe.el
+++ b/poe.el
@@ -31,6 +31,7 @@
 (require 'product)
 (product-provide (provide 'poe) (require 'apel-ver))
 
+(require 'pym)
 
 
 

--- a/poem.el
+++ b/poem.el
@@ -24,6 +24,7 @@
 
 ;;; Code:
 
+(require 'pces)
 (require 'poem-e20)
 
 


### PR DESCRIPTION
Historically, pym.el is part of poe.el, poe.el is part of pces.el,
pces.el is part of poem.el, and applications rely on the dependency.

So, I hope APEL-LB keeps compatibility of APEL.

cf. https://github.com/cvs-m17n-org/MU-CITE/issues/4
