### PR TITLE
Fix fontset-pixel-size failure

### DIFF
--- a/poem-e20.el
+++ b/poem-e20.el
@@ -25,14 +25,10 @@
 ;;; Code:
 
 (defun fontset-pixel-size (fontset)
-  (let* ((info (fontset-info fontset))
-	 (height (aref info 1))
-	 )
-    (cond ((> height 0) height)
-	  ((string-match "-\\([0-9]+\\)-" fontset)
-	   (string-to-number
-	    (substring fontset (match-beginning 1)(match-end 1))))
-	  (t 0))))
+  (cond ((string-match "-\\([0-9]+\\)-" fontset)
+	 (string-to-number
+	  (substring fontset (match-beginning 1) (match-end 1))))
+	(t 0)))
 
 
 ;;; @ character set


### PR DESCRIPTION
* poem-e20.el (fontset-pixel-size): Don't check height, which no
longer exists since Emacs 23.

fontset-pixel-size fails with wrong-type-argument number-or-marker-p,
to reproduce:

```
(progn
  (require 'poem)
  (fontset-pixel-size (car (fontset-list))))
```

Because fontset-info no longer provides leading [ SIZE HEIGHT ... ]
since Emacs 23.  So, removed checking HEIGHT with fontset-info.
